### PR TITLE
feat: add delayEnter prop to decide whether to delay onEnter by a frame or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ yarn add solid-transition-group
 ## Transition
 
 Props:
+
 - name - string Used to automatically generate transition CSS class names. e.g. name: 'fade' will auto expand to .fade-enter, .fade-enter-active, etc.
 - appear - boolean, Whether to apply transition on initial render. Defaults to false.
 - mode - string Controls the timing sequence of leaving/entering transitions. Available modes are "out-in" and "in-out"; defaults to simultaneous.
@@ -34,8 +35,10 @@ Props:
 - exitActiveClass?: string;
 - exitClass?: string;
 - exitToClass?: string;
+- delayEnter?: boolean; (default: true), Whether to delay onEnter callback by one frame or not
 
 Events:
+
 - onBeforeEnter?: (el: Element) => void;
 - onEnter?: (el: Element, done: () => void) => void;
 - onAfterEnter?: (el: Element) => void;
@@ -73,11 +76,12 @@ Usage:
 
 Props:
 
-* moveClass - overwrite CSS class applied during moving transition.
-* exposes the same props as `<Transition>` except mode, appear.
+- moveClass - overwrite CSS class applied during moving transition.
+- exposes the same props as `<Transition>` except mode, appear.
 
 Events:
-* exposes the same events as `<Transition>`.
+
+- exposes the same events as `<Transition>`.
 
 Usage:
 `<TransitionGroup>` serve as transition effects for multiple elements/components.
@@ -87,9 +91,7 @@ Usage:
 ```jsx
 <ul>
   <TransitionGroup name="slide">
-    <For each={state.items}>{
-      item => <li>{item.text}</li>
-    }</For>
+    <For each={state.items}>{item => <li>{item.text}</li>}</For>
   </TransitionGroup>
 </ul>
 ```

--- a/src/Transition.ts
+++ b/src/Transition.ts
@@ -6,7 +6,8 @@ import {
   Component,
   children,
   JSX,
-  createMemo
+  createMemo,
+  mergeProps
 } from "solid-js";
 import { nextFrame } from "./utils";
 
@@ -27,9 +28,12 @@ type TransitionProps = {
   children?: JSX.Element;
   appear?: boolean;
   mode?: "inout" | "outin";
+  delayEnter?: boolean;
 };
 
 export const Transition: Component<TransitionProps> = props => {
+  const merged = mergeProps({ delayEnter: true }, props);
+
   let el: Element;
   let first = true;
   const [s1, set1] = createSignal<Element | undefined>();
@@ -41,12 +45,12 @@ export const Transition: Component<TransitionProps> = props => {
   const classnames = createMemo(() => {
     const name = props.name || "s";
     return {
-      enterActiveClass: props.enterActiveClass || name + "-enter-active",
-      enterClass: props.enterClass || name + "-enter",
-      enterToClass: props.enterToClass || name + "-enter-to",
-      exitActiveClass: props.exitActiveClass || name + "-exit-active",
-      exitClass: props.exitClass || name + "-exit",
-      exitToClass: props.exitToClass || name + "-exit-to"
+      enterActiveClass: name + "-enter-active",
+      enterClass: name + "-enter",
+      enterToClass: name + "-enter-to",
+      exitActiveClass: name + "-exit-active",
+      exitClass: name + "-exit",
+      exitToClass: name + "-exit-to"
     };
   });
 
@@ -58,7 +62,8 @@ export const Transition: Component<TransitionProps> = props => {
       onBeforeEnter && onBeforeEnter(el);
       el.classList.add(...enterClasses);
       el.classList.add(...enterActiveClasses);
-      nextFrame(() => {
+      const run = merged.delayEnter ? nextFrame : requestAnimationFrame;
+      run(() => {
         el.classList.remove(...enterClasses);
         el.classList.add(...enterToClasses);
         onEnter && onEnter(el, () => endTransition());

--- a/src/TransitionGroup.ts
+++ b/src/TransitionGroup.ts
@@ -4,7 +4,8 @@ import {
   createEffect,
   createMemo,
   Component,
-  children
+  children,
+  mergeProps
 } from "solid-js";
 import { nextFrame } from "./utils";
 
@@ -54,8 +55,11 @@ type TransitionGroupProps = {
   onExit?: (el: Element, done: () => void) => void;
   onAfterExit?: (el: Element) => void;
   children?: any;
+  delayEnter?: boolean;
 };
 export const TransitionGroup: Component<TransitionGroupProps> = props => {
+  const merged = mergeProps({ delayEnter: true }, props);
+
   const resolved = children(() => props.children);
   const classnames = createMemo(() => {
     const name = props.name || "s";
@@ -90,7 +94,8 @@ export const TransitionGroup: Component<TransitionGroupProps> = props => {
         onBeforeEnter && onBeforeEnter(el);
         el.classList.add(...enterClasses);
         el.classList.add(...enterActiveClasses);
-        nextFrame(() => {
+        const run = merged.delayEnter ? nextFrame : requestAnimationFrame;
+        run(() => {
           el.classList.remove(...enterClasses);
           el.classList.add(...enterToClasses);
           onEnter && onEnter(el, () => endTransition());


### PR DESCRIPTION
prevents flicker on some animations as mentioned in #3. Decided to make it a prop and not default behavior to not break existing transitions.